### PR TITLE
Fix build on macOS and Debian

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,10 +8,12 @@ LT_INIT
 AC_PROG_CXX
 AX_CXX_COMPILE_STDCXX_14([noext], [mandatory])
 
+AM_PATH_GPG_ERROR(1.46, [], AC_MSG_ERROR([Could not find libgpg-error]))
 AM_PATH_GPGME(1.3.0, [], AC_MSG_ERROR([Could not find GPGME]))
 
-CXXFLAGS="$CXXFLAGS -W -Wall -pthread $GPGME_CFLAGS"
-CFLAGS="$CFLAGS -W -Wall -pthread $GPGME_CFLAGS"
+CXXFLAGS="$CXXFLAGS -W -Wall -pthread $GPGME_CFLAGS $GPG_ERROR_CFLAGS"
+CFLAGS="$CFLAGS -W -Wall -pthread $GPGME_CFLAGS $GPG_ERROR_CFLAGS"
+LIBS="$LIBS $GPGME_LIBS"
 
 AC_ARG_ENABLE(debug,
 	      [  --enable-debug          compile with gdb debug information.],


### PR DESCRIPTION
* `libgpg-error` is required to build `libegpgcrypt` on macOS.

```sh
% make
Making all in include
/Applications/Xcode.app/Contents/Developer/usr/bin/make  all-am
Making all in lib
/bin/sh ../libtool  --tag=CXX   --mode=compile g++ -std=gnu++11 -std=c++14 -DHAVE_CONFIG_H -I. -I../include  -I/opt/homebrew/Cellar/gpgme/1.23.2_1/include   -g -O2 -W -Wall -pthread -I/opt/homebrew/Cellar/gpgme/1.23.2_1/include -g -MT init.lo -MD -MP -MF .deps/init.Tpo -c -o init.lo init.cpp
libtool: compile:  g++ -std=gnu++11 -std=c++14 -DHAVE_CONFIG_H -I. -I../include -I/opt/homebrew/Cellar/gpgme/1.23.2_1/include -g -O2 -W -Wall -pthread -I/opt/homebrew/Cellar/gpgme/1.23.2_1/include -g -MT init.lo -MD -MP -MF .deps/init.Tpo -c init.cpp  -fno-common -DPIC -o .libs/init.o
In file included from init.cpp:2:
/opt/homebrew/Cellar/gpgme/1.23.2_1/include/gpgme.h:30:10: fatal error: 'gpg-error.h' file not found
#include <gpg-error.h>
         ^~~~~~~~~~~~~
1 error generated.
make[1]: *** [init.lo] Error 1
make: *** [all-recursive] Error 1
```

* linking with `libgpgme.so` is needed for the build to succeed on Debian:

```sh
% make
...
/usr/bin/ld: decrypt.o: undefined reference to symbol 'gpgme_data_set_encoding@@GPGME_1.0'
/usr/bin/ld: /lib/aarch64-linux-gnu/libgpgme.so.11: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:396: decrypt] Error 1
```