### PR TITLE
Bugfix: fixed `crypto::has_private_key()`

### DIFF
--- a/lib/crypto.cpp
+++ b/lib/crypto.cpp
@@ -87,7 +87,7 @@ void crypto::sign(const std::set<std::string>& email_addresses, const data_buffe
     for (auto&& email_address : email_addresses)
         ptns.add(email_address);
 
-    gpgme_error_t err = gpgme_op_keylist_ext_start(ctx.ctx(), ptns.char_patterns(), 0, 0);
+    gpgme_error_t err = gpgme_op_keylist_ext_start(ctx.ctx(), ptns.char_patterns(), 1, 0);
 
     if (err != GPG_ERR_NO_ERROR)
         throw std::runtime_error("key list error: " + egpg_gpgme_strerror(err));
@@ -99,7 +99,7 @@ void crypto::sign(const std::set<std::string>& email_addresses, const data_buffe
         if (err != GPG_ERR_NO_ERROR)
             break;
 
-        if (!is_valid_key(key, false, false)) {
+        if (!is_valid_key(key, true, false)) {
             gpgme_key_unref(key);
             continue;
         }
@@ -160,7 +160,7 @@ bool crypto::has_private_key(const std::string& email) const
 {
     context ctx(protocol_);
 
-    return ctx.find_key(email, true, true);
+    return ctx.find_key(email, true, false);
 }
 
 bool crypto::is_valid_key(gpgme_key_t key, bool secret, bool for_encryption) const

--- a/tests/query_keys.cpp
+++ b/tests/query_keys.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv)
         context ctx;
 
         if (!secret_pattern.empty()) {
-            key k = ctx.find_key(secret_pattern, true);
+            key k = ctx.find_key(secret_pattern, true, false);
             print_key(k);
         }
 


### PR DESCRIPTION
This PR contains the following changes:
* `crypto::has_private_key()` now works correctly when a key contains only the private part:
```
% gpg -K private-key-only
sec   ed25519 2024-07-14 [SC]
      2B5EC<...>
uid           [ultimate] private-key-only@example.com

# === before the fix ===
% ./query_keys -p private-key-only
No key found.
% ./query_keys -s private-key-only
No key found.

# === after the fix ===
% ./query_keys -p private-key-only
No key found.
% ./query_keys -s private-key-only
Key found for address <private-key-only@example.com>.
revoked: false, expired: false, invalid: false, disabled: false, secret: true, can_encrypt: false
expires: Thu Jan  1 02:00:00 1970
```

It works correctly in other scenarios, too:
```
# === public key only ===
% ./query_keys -p public-key-only
Key found for address <public-key-only@example.com>.
revoked: false, expired: false, invalid: false, disabled: false, secret: false, can_encrypt: true
expires: Thu Jan  1 02:00:00 1970

% ./query_keys -s public-key-only
No key found.

# === key with public and private parts ===
% ./query_keys -p pgp
Key found for address <pgp@example.com>.
revoked: false, expired: false, invalid: false, disabled: false, secret: false, can_encrypt: true
expires: Thu Jan  1 02:00:00 1970

% ./query_keys -s pgp
Key found for address <pgp@example.com>.
revoked: false, expired: false, invalid: false, disabled: false, secret: true, can_encrypt: true
expires: Thu Jan  1 02:00:00 1970
```

* minor improvement in how `crypto::sign()` looks up keys: it now lists only the keys that have a secret part (`gpgme_op_keylist_ext_start()`). Also, I updated the call to `is_valid_key()` to reflect this change.
* updated the `tests/query_keys`